### PR TITLE
Remove Google Analytics and social media meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-P80TLT99Q7"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-P80TLT99Q7');
-</script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -17,19 +8,6 @@
     <meta name="description" content="TinyWebP is a lightweight tool to convert JPG, PNG, GIF, and more to WebP format with ease." />
     <meta name="keywords" content="webp converter, image compression, jpg to webp, png to webp" />
     <meta name="author" content="Isuru Prabath" />
-
-    <!-- Open Graph Meta (for social media sharing) -->
-    <meta property="og:title" content="TinyWebP - Convert Images to WebP" />
-    <meta property="og:description" content="Easily convert JPG, PNG, GIF, and more to WebP format with TinyWebP." />
-    <meta property="og:image" content="https://tinywebp.app/social_tinywebp.webp" />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://tinywebp.app" />
-
-    <!-- Twitter Meta -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="TinyWebP - Convert Images to WebP" />
-    <meta name="twitter:description" content="Easily convert JPG, PNG, GIF, and more to WebP format with TinyWebP." />
-    <meta name="twitter:image" content="https://tinywebp.app/social_tinywebp.webp" />
 
     <link rel="icon" type="image/png" href="/favicon-96x96.webp" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
This commit removes the Google Analytics script and associated meta tags for Open Graph and Twitter. This simplifies the HTML structure, reducing external dependencies and improving privacy.